### PR TITLE
Update the approach to opening windows in the background

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Here are new or changed commands:
 - `choose_window`--This is a simple window selector that shows the available windows ordered by space. It's good enough to reduce the need for something like AltTab.
 - `next_screen`--Focus the next screen (note that the next screen needs a space in which to focus).
 - `space_to_next_screen`--Move the active space to the next screen.
+- `toggle_open_in_background`--Toggles whether windows open next to the focused window in the background. Only for windows in `PaperWM.apps_open_in_background`. A variable `PaperWM.one_shot_open_in_background` is also available to enable opening the next window in the background. That's useful for application-specific hotkeys. 
 
 There are still bugs:
 
@@ -140,7 +141,9 @@ With the `PaperWM.apps_open_in_background` option, you can set new browser windo
 
 ## Other apps that work well with scrolling windows
 
-Terminal-based apps, including editors like Helix work great with scrolling windows.
+Terminal-based apps, including editors like Helix work great with scrolling windows. Kitty works well because it has the `--single-instance` option to use the same instance of kitty. That and the `--title` option are useful for hotkeys and scripts.
+
+Note that windows opened with `open -n -a ...` don't work with PaperWM. This is a Hammerspoon bug ([3235](https://github.com/Hammerspoon/hammerspoon/issues/3235), [3596](https://github.com/Hammerspoon/hammerspoon/issues/3596)).
 
 VS Code has the option "Move into New Window" for tabs. That works nicely.
 

--- a/init.lua
+++ b/init.lua
@@ -109,6 +109,7 @@ PaperWM.space_names = {1, 2, 3, 4, 5, 6, 7, 8, 9}
 
 -- apps that open new windows in the background automatically
 PaperWM.apps_open_in_background = {}
+PaperWM.one_shot_open_in_background = false
 
 
 ---First index of `value` in `array`; also used to check if `value` exists in `array`
@@ -807,9 +808,10 @@ function PaperWM:addWindow(add_window, space)
             screen_num = window_list.spaces[default_space].screen_num
             space = default_space
         end
-        if open_in_background or 
-           (same_app and focused_window and indexOf(PaperWM.apps_open_in_background, focused_window:application():title())) then
+        if (open_in_background or self.one_shot_open_in_background) and 
+           same_app and focused_window and indexOf(PaperWM.apps_open_in_background, focused_window:application():title()) then
             window_stay = copy(focused_window)
+            self.one_shot_open_in_background = false
         end
     end
     screen_num = screen_num or indexOf(window_list.screen_ids, add_window:screen():id())

--- a/init.lua
+++ b/init.lua
@@ -158,7 +158,7 @@ local IsFloatingKey <const> = 'PaperWM_is_floating'
 local window_columns = hs.settings.get("PaperWM_window_columns") or {}
 
 -- array of windows sorted from left to right
-window_list = {} -- 2D array of tiles by space in order of .spaces[space][x][y]
+local window_list = {} -- 2D array of tiles by space in order of .spaces[space][x][y]
                        -- also stores 
                        --   .active_space
                        --   .screen_active_space[]
@@ -1512,6 +1512,7 @@ end
 
 function PaperWM:toggleOpenInBackground()
     open_in_background = not open_in_background
+    hs.alert.show("Open in background turned " .. (open_in_background and "on." or "off."))
 end
 
 function PaperWM:tileAll()

--- a/init.lua
+++ b/init.lua
@@ -107,6 +107,10 @@ PaperWM.window_filter = WindowFilter.new():setOverrideFilter({
 -- default space_names
 PaperWM.space_names = {1, 2, 3, 4, 5, 6, 7, 8, 9}
 
+-- apps that open new windows in the background automatically
+PaperWM.apps_open_in_background = {}
+
+
 ---First index of `value` in `array`; also used to check if `value` exists in `array`
 ---@param array Array
 ---@param value 
@@ -171,6 +175,7 @@ local is_floating = {} -- dictionary of boolean with window id for keys
 local menubar = hs.menubar.new(true, "spaceindicator")
 local last_focused_app = "" -- stores the name of the last app with focus
 local animation_duration = 0
+local open_in_background = false
 
 local function updateMenu()
     local title = ""
@@ -802,7 +807,8 @@ function PaperWM:addWindow(add_window, space)
             screen_num = window_list.spaces[default_space].screen_num
             space = default_space
         end
-        if same_app and focused_window and indexOf(PaperWM.apps_open_in_background, focused_window:application():title()) then
+        if open_in_background or 
+           (same_app and focused_window and indexOf(PaperWM.apps_open_in_background, focused_window:application():title())) then
             window_stay = copy(focused_window)
         end
     end
@@ -1502,6 +1508,10 @@ function PaperWM:closeWindowsInSpace()
     end
 end
 
+function PaperWM:toggleOpenInBackground()
+    open_in_background = not open_in_background
+end
+
 function PaperWM:tileAll()
     for _, space in ipairs(window_list.space_names) do
         self:tileSpace(space)
@@ -1707,6 +1717,7 @@ PaperWM.actions = {
     slurp_in = partial(PaperWM.slurpWindow, PaperWM),
     barf_out = partial(PaperWM.barfWindow, PaperWM),
     choose_window = partial(PaperWM.chooseWindow, PaperWM),
+    toggle_open_in_background = partial(PaperWM.toggleOpenInBackground, PaperWM),
 }
 
 ---bind userdefined hotkeys to PaperWM actions


### PR DESCRIPTION
- Adds a command to toggle whether to open windows in the background.
- Adds a variable to force the next window to be opened in the background. This can be used with hotkeys, so the user can direct a browser link to open in the background.